### PR TITLE
Freeze surefire version to fix runs in docker

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,15 @@
                 <artifactId>maven-project-info-reports-plugin</artifactId>
                 <version>2.7</version>
             </plugin>
+
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-surefire-plugin</artifactId>
+                <version>2.22.1</version>
+                <configuration>
+                    <useSystemClassLoader>false</useSystemClassLoader>
+                </configuration>
+            </plugin>
         </plugins>
     </build>
 


### PR DESCRIPTION
Without this fix, tests run in docker fail with following error
```
-------------------------------------------------------
 T E S T S
-------------------------------------------------------
Error: Could not find or load main class org.apache.maven.surefire.booter.ForkedBooter

Results :

Tests run: 0, Failures: 0, Errors: 0, Skipped: 0

[ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:2.17:test (default-test) on project rdap-conformance: Execution default-test of goal org.apache.maven.plugins:maven-surefire-plugin:2.17:test failed: The forked VM terminated without properly saying goodbye. VM crash or System.exit called?
[ERROR] Command was /bin/sh -c cd /builds/fred/rdap/rdap-conformance && /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java -jar /builds/fred/rdap/rdap-conformance/target/surefire/surefirebooter2661948662614589477.jar /builds/fred/rdap/rdap-conformance/target/surefire/surefire5122227275567469077tmp /builds/fred/rdap/rdap-conformance/target/surefire/surefire_07750448676402480100tmp
[ERROR] -> [Help 1]
[ERROR] 
[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.
[ERROR] Re-run Maven using the -X switch to enable full debug logging.
[ERROR] 
[ERROR] For more information about the errors and possible solutions, please read the following articles:
[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException
ERROR: Job failed: exit code 1
```

I wasn't able to reproduce the error outside of the docker.