### PR TITLE
Replace docker entrypoint with command

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,8 +18,8 @@ RUN cd /build && \
     $M2_HOME/bin/mvn verify -DskipDocker && \
     mkdir /app && \
     cp target/*.jar /app && \
-    cp target/docker-extras/entrypoint.sh /app/ && \
-    chmod 0744 /app/entrypoint.sh && \
+    cp target/docker-extras/rdap-conformance /usr/local/bin/ && \
+    chmod 0777 /usr/local/bin/rdap-conformance && \
     cd / && \
     rm -rf /build ${M2_HOME}
 
@@ -31,4 +31,4 @@ RUN useradd -MrU conformance && \
 
 EXPOSE 8080
 USER conformance
-ENTRYPOINT ["/app/entrypoint.sh", "/rdap-config/rdap-configuration.json"]
+CMD ["rdap-conformance", "/rdap-config/rdap-configuration.json"]

--- a/src/main/docker/entrypoint.sh
+++ b/src/main/docker/entrypoint.sh
@@ -1,5 +1,0 @@
-#!/bin/bash
-
-echo "Launching with arguments: $@"
-
-exec java -jar @project.artifactId@-@project.version@.@project.packaging@ "$\@"

--- a/src/main/docker/rdap-conformance
+++ b/src/main/docker/rdap-conformance
@@ -1,0 +1,3 @@
+#!/bin/sh
+echo "Launching conformance test with arguments: $*"
+java -jar @project.artifactId@-@project.version@.@project.packaging@ "$\@"


### PR DESCRIPTION
I've replaced the docker entrypoint with a utility command. This way a plain running of docker container works the same, but it is possible to easily override command to be run, i.e. ```docker run --rm -ti apnic-conformance /bin/bash```.